### PR TITLE
:sparkles: (minor) Add response timeout time to rx64

### DIFF
--- a/demos/applications/drc_v2.cpp
+++ b/demos/applications/drc_v2.cpp
@@ -47,6 +47,8 @@ void application()
       hal::actuator::rmd_drc_v2 drc(
         *can_transceiver, *can_identifier_filter, *clock, 6.0f, address);
 
+      hal::print<128>(*console, "RMD DRC ID = 0x%02X\n", address);
+
       auto print_feedback = [&drc, &console]() {
         drc.feedback_request(hal::actuator::rmd_drc_v2::read::status_2);
         drc.feedback_request(
@@ -100,27 +102,27 @@ void application()
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(0.0_deg, 50.0_rpm);
+        drc.position_control(0.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(-45.0_deg, 50.0_rpm);
+        drc.position_control(-45.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(90.0_deg, 50.0_rpm);
+        drc.position_control(90.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(180.0_deg, 50.0_rpm);
+        drc.position_control(180.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(-360.0_deg, 50.0_rpm);
+        drc.position_control(-360.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
 
-        drc.position_control(0.0_deg, 50.0_rpm);
+        drc.position_control(0.0_deg, 5.0_rpm);
         hal::delay(*clock, 5000ms);
         print_feedback();
       }

--- a/demos/platforms/stm32f103c8.cpp
+++ b/demos/platforms/stm32f103c8.cpp
@@ -14,7 +14,7 @@
 
 #include <libhal-arm-mcu/dwt_counter.hpp>
 #include <libhal-arm-mcu/startup.hpp>
-#include <libhal-arm-mcu/stm32f1/can.hpp>
+#include <libhal-arm-mcu/stm32f1/can2.hpp>
 #include <libhal-arm-mcu/stm32f1/clock.hpp>
 #include <libhal-arm-mcu/stm32f1/constants.hpp>
 #include <libhal-arm-mcu/stm32f1/output_pin.hpp>
@@ -126,19 +126,46 @@ hal::v5::strong_ptr<hal::output_pin> status_led()
   return status_led_ptr;
 }
 
+hal::v5::optional_ptr<hal::stm32f1::can_peripheral_manager_v2> can_manager;
+
+void initialize_can()
+{
+  if (not can_manager) {
+    auto clock_ref = clock();
+    can_manager =
+      hal::v5::make_strong_ptr<hal::stm32f1::can_peripheral_manager_v2>(
+        driver_allocator(),
+        32,
+        driver_allocator(),
+        100'000,
+        *clock_ref,
+        std::chrono::milliseconds(1),
+        hal::stm32f1::can_pins::pb9_pb8);
+  }
+}
+
 hal::v5::strong_ptr<hal::can_transceiver> can_transceiver()
 {
-  throw hal::operation_not_supported(nullptr);
+  initialize_can();
+  return hal::acquire_can_transceiver(driver_allocator(), can_manager);
 }
 
 hal::v5::strong_ptr<hal::can_bus_manager> can_bus_manager()
 {
-  throw hal::operation_not_supported(nullptr);
+  initialize_can();
+  return hal::acquire_can_bus_manager(driver_allocator(), can_manager);
 }
 
 hal::v5::strong_ptr<hal::can_identifier_filter> can_identifier_filter()
 {
-  throw hal::operation_not_supported(nullptr);
+  initialize_can();
+  return hal::acquire_can_identifier_filter(driver_allocator(), can_manager)[0];
+}
+
+hal::v5::strong_ptr<hal::can_interrupt> can_interrupt()
+{
+  initialize_can();
+  return hal::acquire_can_interrupt(driver_allocator(), can_manager);
 }
 
 hal::v5::strong_ptr<hal::pwm> pwm()

--- a/include/libhal-actuator/mx_64.hpp
+++ b/include/libhal-actuator/mx_64.hpp
@@ -501,7 +501,7 @@ private:
     try {
       using namespace std::chrono_literals;
       auto const response =
-        hal::read<6>(*m_serial, hal::create_timeout(*m_clock, 500ms));
+        hal::read<6>(*m_serial, hal::create_timeout(*m_clock, 50ms));
       if (response[0] == 0xFF && response[1] == 0xFF) {
         // device responded
         hal::byte received_chksm =

--- a/include/libhal-actuator/rx_64.hpp
+++ b/include/libhal-actuator/rx_64.hpp
@@ -17,6 +17,7 @@
 // only once, no matter how many times it is included.
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 
 #include <array>
@@ -60,6 +61,9 @@ public:
     hal::degrees max_angle = 300;
     /// @brief Enable torque on setup
     bool torque_enable = true;
+    /// @brief Time before assuming that there was an error response from the
+    /// motor
+    hal::time_duration response_timeout = std::chrono::milliseconds(50);
   };
 
   /**
@@ -361,6 +365,19 @@ public:
    */
   void sync_position(hal::degrees p_angle, rx_64 p_opposing_servo);
 
+  /**
+   * @brief Returns the last error code retrieved from the servo motor
+   *
+   * See https://docs.robotis.com/docs/dxl/protocol/protocol1/#error for error
+   * code information.
+   *
+   * @return auto - error code byte
+   */
+  [[nodiscard]] auto last_error_code() const
+  {
+    return m_last_error;
+  }
+
 private:
   /**
    * @brief Addresses for registers of rx_64
@@ -457,8 +474,8 @@ private:
     try {
       auto constexpr read_size = 6 + Size;
 
-      auto const response =
-        hal::read<read_size>(*m_serial, hal::create_timeout(*m_clock, 500ms));
+      auto const response = hal::read<read_size>(
+        *m_serial, hal::create_timeout(*m_clock, m_response_timeout));
       if (response[0] == 0xFF && response[1] == 0xFF) {
         // device responded
         // TODO(#47): check for errors
@@ -488,24 +505,28 @@ private:
     checksum = std::accumulate(p_data.begin(), p_data.end(), checksum);
     checksum = ~checksum;
 
-    hal::write(*m_serial, header_bytes, hal::never_timeout());
-    hal::write(*m_serial, p_data, hal::never_timeout());
-    hal::write(*m_serial, std::array{ checksum }, hal::never_timeout());
-
+    m_last_error = 0;
     try {
-      using namespace std::chrono_literals;
-      auto const response =
-        hal::read<6>(*m_serial, hal::create_timeout(*m_clock, 500ms));
-      if (response[0] == 0xFF && response[1] == 0xFF) {
-        // device responded
-        hal::byte received_chksm =
-          std::accumulate(&response[2], &response[4], 0);
-        received_chksm = ~received_chksm;
-        if (received_chksm == response[5]) {
-          // checksum match
-          // TODO(#47): check for errors
+      do {
+        hal::write(*m_serial, header_bytes, hal::never_timeout());
+        hal::write(*m_serial, p_data, hal::never_timeout());
+        hal::write(*m_serial, std::array{ checksum }, hal::never_timeout());
+
+        auto const response = hal::read<6>(
+          *m_serial, hal::create_timeout(*m_clock, m_response_timeout));
+        if (response[0] == 0xFF && response[1] == 0xFF) {
+          // device responded
+          hal::byte received_chksm =
+            std::accumulate(&response[2], &response[4], 0);
+          received_chksm = ~received_chksm;
+          m_last_error = response[4];
+          if (received_chksm == response[5]) {
+            // checksum match
+            // TODO(#47): check for errors
+          }
         }
-      }
+        // check if the last error had a checksum error
+      } while (m_last_error & (1 << 4));
     } catch (hal::timed_out const&) {
       return;
     }
@@ -514,6 +535,8 @@ private:
   hal::strong_ptr<hal::serial> m_serial;
   hal::strong_ptr<hal::steady_clock> m_clock;
   std::pair<hal::degrees, hal::degrees> m_range;
+  hal::time_duration m_response_timeout;
   hal::byte m_id;
+  hal::byte m_last_error;
 };
 }  // namespace hal::actuator

--- a/src/rx_64.cpp
+++ b/src/rx_64.cpp
@@ -42,6 +42,7 @@ rx_64::rx_64(hal::strong_ptr<hal::serial> const& p_serial,
              hal::strong_ptr<hal::steady_clock> const& p_clock)
   : m_serial(p_serial)
   , m_clock(p_clock)
+  , m_response_timeout(p_settings.response_timeout)
   , m_id(p_settings.id)
 {
   using namespace std::chrono_literals;


### PR DESCRIPTION
Additional changes:

- Slow down DRC demo
- Add can drivers to stm32f103c8 platform file.

Manually tested.